### PR TITLE
added a rOpenSci footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ str(FrenchHostPars)
 ### Contribute!
 This is a very recent creation, and will be changed pretty often as I find time to update it. Feel free to fork it and contribute some functionality. 
 
+
+[![ropensci_footer](http://ropensci.org/public_images/github_footer.png)](http://ropensci.org)


### PR DESCRIPTION
Hi @taddallas 
I added a standard rOpenSci footer that we add to all repos in the suite.  Makes the README look like this:

![image](https://cloud.githubusercontent.com/assets/138494/5924290/69745e00-a60f-11e4-9a4b-feac1086cd23.png)
