### PR TITLE
change travis file to use newer R lang setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,6 @@
-language: c
-sudo: required
-
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-  - ./travis-tool.sh install_deps
-  - ./travis-tool.sh install_github jimhester/covr
-
-script:
-  - ./travis-tool.sh run_tests
+language: r
+sudo: false
+cache: packages
 
 after_success:
   - Rscript -e 'library(covr); codecov(token = "9ee67667-7a10-406c-a982-23c86af5d682" )'


### PR DESCRIPTION
and cache: packages, sudo: false to speed up builds

hey @taddallas   - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropensci/helminthR/builds/209113093 isn't faster than the others on the first run, but should be faster the next time since deps are cached

docs for R language on travis https://docs.travis-ci.com/user/languages/r